### PR TITLE
Remove usage of StyleablePart

### DIFF
--- a/aa_plugin/src/main/java/com/futureworkshops/mobileworkflow/plugin/aa/view/UIAAPart.kt
+++ b/aa_plugin/src/main/java/com/futureworkshops/mobileworkflow/plugin/aa/view/UIAAPart.kt
@@ -8,15 +8,13 @@ import android.content.Context
 import android.util.AttributeSet
 import android.view.View
 import android.widget.FrameLayout
-import com.futureworkshops.mobileworkflow.SurveyTheme
-import com.futureworkshops.mobileworkflow.backend.views.main_parts.StyleablePart
 import com.futureworkshops.mobileworkflow.plugin.aa.R
 
 class UIAAPart @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,
     defStyleRes: Int = 0
-) : FrameLayout(context, attrs, defStyleRes), StyleablePart {
+) : FrameLayout(context, attrs, defStyleRes) {
 
     val view: View = View.inflate(context, R.layout.aa_plugin_step, this)
 
@@ -27,10 +25,4 @@ class UIAAPart @JvmOverloads constructor(
     private fun createViews() {
 
     }
-
-    override fun style(surveyTheme: SurveyTheme) {
-    }
-
-
-
 }

--- a/aa_plugin/src/main/java/com/futureworkshops/mobileworkflow/plugin/aa/view/UIAAPluginView.kt
+++ b/aa_plugin/src/main/java/com/futureworkshops/mobileworkflow/plugin/aa/view/UIAAPluginView.kt
@@ -251,7 +251,6 @@ internal class UIAAPluginView(
         context?.let { safeContext ->
             footer.visibility = View.GONE
             aAPart = UIAAPart(safeContext)
-            aAPart.style(surveyTheme)
             content.add(aAPart)
         }
 


### PR DESCRIPTION
### Checklist

- [x] I've validated if any R8 rule should be added to the relevant proguard-rules.pro file. More info about it [on Confluence](https://futureworkshops.atlassian.net/wiki/spaces/FMW/pages/2319187983/Validate+R8+rules+for+core+and+plugins)
- [X] If I'm updating a plugin submodule, I'm sure that the reference on the submodule is on `main`

### Task

[Remove usage of StyleablePart](https://3.basecamp.com/5245563/buckets/26795773/todos/4780099243)

### Feature/Issue

Currently many steps use StyleablePart interface to receive the themeSurvey and extract the tint color from it. This interface should be removed from the code base, as each steps should use the theme of the app.

### Implementation

Remove the use of StyleablePart, and move any needed code from the interface implementation to another part of the step's code.